### PR TITLE
Various internal refactor proposals

### DIFF
--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -29,7 +29,7 @@ require([
 	**/
 	$(document.body).on('click', 'a', function (evnt) {
 
-		if ( !('pushState' in window.history) || /^\/(wp-login|wp-admin)/.test(this.pathname) ) {
+		if ( !('pushState' in window.history) || /\/(wp-login|wp-admin)/.test(this.pathname) ) {
 			return true;
 		}
 

--- a/assets/scripts/views/body-view.js
+++ b/assets/scripts/views/body-view.js
@@ -31,7 +31,6 @@ define(['app'], function (app) {
 
 			this
 				.$el
-				.removeClass('request-pending')
 				.addClass('content-inserted');
 
 			_.delay(function (that) {
@@ -43,6 +42,7 @@ define(['app'], function (app) {
 			_.delay(function (that) {
 				that
 					.$el
+ 					.removeClass('request-pending')
 					.removeClass('content-inserted');
 			}, 900, this);
 

--- a/functions.php
+++ b/functions.php
@@ -19,6 +19,13 @@ remove_action('wp_head', 'rsd_link');
 remove_action('wp_head', 'start_post_rel_link', 10, 0);
 remove_action('wp_head', 'adjacent_posts_rel_link_wp_head', 10, 0);
 
+
+add_filter('the_date', 'format_the_date');
+function format_the_date($unixtimestamp) {
+    return strftime(get_option('date_format'), $unixtimestamp);
+}
+
+
 function bb_remove_annoying_stuff() {
 	wp_deregister_script('l10n');
 }

--- a/header.php
+++ b/header.php
@@ -6,18 +6,14 @@
 <!--[if !IE]><!--> <html class="no-js modern" <?php language_attributes(); ?>> <!--<![endif]-->
 <head>
 	<meta charset="<?php bloginfo('charset'); ?>">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-
 	<!-- make sure google et al. opts in to the hashbang-party -->
 	<meta name="fragment" content="!">
-
 	<base href="<?php bloginfo('url'); ?>/">
 	<meta name="viewport" content="width=device-width">
 	<link rel="stylesheet" media="all" href="<?php bloginfo('stylesheet_url'); ?>">
 	<title><?php wp_title( ' | ', true, 'right' ); ?><?php bloginfo('name'); ?></title>
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 	<link rel="pingback" href="<?php bloginfo('pingback_url'); ?>">
-
 	<?php wp_head(); ?>
 </head>
 <body <?php body_class(); ?>>

--- a/header.php
+++ b/header.php
@@ -20,5 +20,5 @@
 
 	<?php wp_head(); ?>
 </head>
-<body<?php bb_body_class(); ?>>
+<body <?php body_class(); ?>>
 <?php endif; ?>

--- a/inc/classes/BB-Controller.class.php
+++ b/inc/classes/BB-Controller.class.php
@@ -41,7 +41,7 @@ class BackbonedController {
 			return $GLOBALS['bb_controller'];
 		}
 
-
+		header('X-UA-Compatible: content="IE=edge,chrome=1');
 		header('X-Request-type: '.$this->request_type());
 
 		// We can support child theme views folder

--- a/inc/classes/BB-Controller.class.php
+++ b/inc/classes/BB-Controller.class.php
@@ -9,7 +9,7 @@ Mustache_Autoloader::register();
 /*
  * Backboned Controller
 **/
-class Backboned {
+class BackbonedController {
 
 	/**
 	 * @var string
@@ -21,22 +21,140 @@ class Backboned {
 	 */
 	protected $wp_model;
 
-	public function __construct() {
+	/**
+	 * BackbonedController constructor
+	 *
+	 * There should be only one instance of this object. The
+	 * constructor takes care to add filters it needs to generate the
+	 * pages and handle the Request Response cycle.
+	 *
+	 * Ideally, we should refactor toward Symfony2 http_kernel and specialize
+	 * exclusively for the theme.
+	 *
+	 * http://symfony.com/doc/current/components/http_kernel/introduction.html
+	 *
+	 * @param [type] $WP_Instance [description]
+	 */
+	public function __construct(&$WP_Instance) {
 
-		$this->root = dirname(dirname(dirname(__FILE__)));
+		if ( isset($GLOBALS['bb_controller']) && $GLOBALS['bb_controller'] instanceof BackbonedController ) {
+			return $GLOBALS['bb_controller'];
+		}
+
+
+		header('X-Request-type: '.$this->request_type());
+
+		// We can support child theme views folder
+		$this->root = get_stylesheet_directory();
+
 		$this->wp_model = new WP_Model();
 
-		$this->mustache = new Mustache_Engine(array(
-			'cache' => $this->root . '/cache/mustache',
-			'cache_file_mode' => 0666,
-			'loader' => new Mustache_Loader_FilesystemLoader($this->root . '/views'),
-			'partials_loader' => new Mustache_Loader_FilesystemLoader($this->root . '/views/partials'),
-			'escape' => function($value) {
-				return htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
-			},
-			'charset' => 'utf-8'
-		));
+		$this->_initMustache();
 
+		add_filter( 'body_class', array( $this, 'body_class' ) );
+
+		add_filter( 'the_date', array( $this->wp_model, 'date_format' ) );
+
+		add_action( 'init', array( $this, 'init_deregister_unused_scripts' ), 9 );
+
+		add_action( 'wp_head', array( $this, 'wp_head_cleanup' ), 9 );
+
+		add_action( 'wp_footer', array( $this, 'wp_footer_scripts_echo' ), 5 );
+
+		add_action( 'wp_footer', array( $this, 'wp_footer_partials_echo'), 5 );
+
+		add_action( 'wp_head', array( $this, 'wp_head_js_vars_echo' ), 5 );
+
+		return $this;
+	}
+
+	/**
+	 * If it’s not a search-engine-crawler visiting the site,
+	 * the right body-class is set to hide the empty
+	 * content-element.
+	 **/
+	public function body_class($classNames) {
+
+		$classes = (array) $classNames;
+
+		if ( $this->request_type() == 'standard' ) {
+			$classes[] = 'request-pending';
+		} elseif ( $this->request_type() == 'search_engine' ) {
+			$classes[] = 'content-ready';
+		}
+
+		return $classes;
+	}
+
+	public function init_deregister_unused_scripts() {
+		wp_deregister_script('l10n');
+	}
+
+  /**
+   * Add our own JavaScript bootstrap hook
+   **/
+	public function wp_footer_scripts_echo() {
+
+		if ( $this->request_type() != 'standard' ) {
+			return;
+		}
+
+		echo $this->get('js_scripts');
+	}
+
+	/**
+	 * Writing the templates to the DOM
+	 **/
+	function wp_footer_partials_echo() {
+
+		if ( $this->request_type() != 'standard' ) {
+			return;
+		}
+
+		echo $this->get('partials');
+	}
+
+	/**
+	 * JS-Variables-Hook
+	 **/
+	function wp_head_js_vars_echo() {
+
+		if ( $this->request_type() != 'standard' ) {
+			return;
+		}
+
+		$js_variables = $this->get('js_variables');
+
+		echo '<script>var BB = ' . json_encode($js_variables) . ';</script>';
+	}
+
+	/**
+	 * Removing annoying stuff from the HTML-head
+	 **/
+	public function wp_head_cleanup() {
+		remove_action('wp_head', 'wp_generator');
+		remove_action('wp_head', 'wlwmanifest_link');
+		remove_action('wp_head', 'rsd_link');
+		remove_action('wp_head', 'start_post_rel_link', 9, 0);
+		remove_action('wp_head', 'adjacent_posts_rel_link_wp_head', 9, 0);
+	}
+
+	/**
+	 * Initialize Mustache
+	 *
+	 * @return void
+	 */
+	private function _initMustache() {
+		$mustache_options['cache'] = $this->root . '/cache/mustache';
+		$mustache_options['cache_file_mode'] = 0666;
+		$mustache_options['loader'] = new Mustache_Loader_FilesystemLoader($this->root . '/views');
+		$mustache_options['partials_loader'] = new Mustache_Loader_FilesystemLoader($this->root . '/views/partials');
+		$mustache_options['escape'] = function($value) {
+			return htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
+		};
+		$mustache_options['charset'] = 'utf-8';
+
+		$this->mustache = new Mustache_Engine($mustache_options);
 	}
 
 	/*
@@ -54,23 +172,27 @@ class Backboned {
 
 	}
 
-	/*
+	/**
 	 * Check, wether it's a normal request, an async
 	 * request or an request by a search engine crawler.
 	 *
+	 * Also adds an HTTP response header (X-Request-type: ) so we can traceback.
+	 *
 	 * @return string
-	**/
+	 **/
 	public function request_type() {
 
+		$type = 'standard';
+
 		if ( isset($_GET['_escaped_fragment_']) ) {
-			return 'search_engine';
+			$type = 'search_engine';
 		}
 
 		if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest' ) {
-			return 'async';
+			$type = 'async';
 		}
 
-		return 'standard';
+		return $type;
 
 	}
 
@@ -83,7 +205,7 @@ class Backboned {
 	public function content($type = 'loop') {
 
 		if ( is_404() ) {
-			return $this->__generate_404();
+			return $this->__generate_error(404);
 		}
 
 		return $this->{'__generate_' . $type}();
@@ -142,10 +264,15 @@ class Backboned {
 
 	}
 
-	/*
-	 * The Error page
-	**/
-	protected function __generate_404() {
+	/**
+	 * The Error view
+	 **/
+	protected function __generate_error($http_code=404) {
+		$code = 404;
+
+		if ( in_array($http_code, $this->wp_model->get_supported_errors()) ) {
+			$code = (int) $http_code;
+		}
 
 		$request_type = $this->request_type();
 
@@ -154,7 +281,9 @@ class Backboned {
 			return;
 		}
 
-		$error = $this->wp_model->get('404');
+		// Make sure we have each equivalent codes
+		// in there too.
+		$error = $this->wp_model->get('error', $code);
 
 		if ( $request_type == 'async' ) {
 
@@ -169,14 +298,16 @@ class Backboned {
 
 		$content = array_merge($this->get('frame'), $error);
 
+		// Change views/404.mustache for generic-er error document #TODO
 		$layout = $this->mustache->loadTemplate('404');
+		// If we wanted i18n on PHP side, that’s where we’d inject it #TODO
 		echo $layout->render($content);
 
 	}
 
-	/*
+	/**
 	 * Output for the loop due to request type
-	**/
+	 **/
 	protected function __generate_loop() {
 
 		$request_type = $this->request_type();
@@ -205,6 +336,7 @@ class Backboned {
 		$content['posts'] = $posts;
 
 		$layout = $this->mustache->loadTemplate('loop');
+		// If we wanted i18n on PHP side, that’s where we’d inject it #TODO
 		echo $layout->render($content);
 
 	}
@@ -246,6 +378,7 @@ class Backboned {
 		$content['comments'] = $comments;
 
 		$layout = $this->mustache->loadTemplate('single');
+		// If we wanted i18n on PHP side, that’s where we’d inject it #TODO
 		echo $layout->render($content);
 
 	}
@@ -282,10 +415,16 @@ class Backboned {
 
 		}
 
+		/**
+		 * from this point on, the request URL should have ?_escaped_fragment_
+		 * and therefore be a $request_type === 'search_engine'
+		 */
+
 		$content = array_merge($content, $this->get('frame'), $commentform);
 		$content['comments'] = $comments;
 
 		$layout = $this->mustache->loadTemplate('page');
+		// If we wanted i18n on PHP side, that’s where we’d inject it #TODO
 		echo $layout->render($content);
 
 	}
@@ -298,9 +437,9 @@ class Backboned {
 	protected function __get_js_variables() {
 
 		$variables = array(
-			'dev_mode' => $_SERVER['HTTP_HOST'] === 'wp.dev',
+			'dev_mode' => (bool) preg_match("/localhost/", $_SERVER['HTTP_HOST']),
 			'base_url' => get_option('home'),
-			'template_url' => get_bloginfo('template_url'),
+			'template_url' => get_stylesheet_directory_uri(),
 			'logged_in' => is_user_logged_in(),
 			'site_header' => $this->wp_model->get('site_header'),
 			'main_nav' => $this->wp_model->get('main_nav'),
@@ -323,9 +462,10 @@ class Backboned {
 	**/
 	protected function __get_js_scripts() {
 
-		$str = '<script src="' . get_bloginfo('template_url');
+		// get_stylesheet_directory_uri() will also work with child themes
+		$str = '<script src="' . get_stylesheet_directory_uri();
 		$str .= '/assets/vendor/requirejs/require.js"';
-		$str .= ' data-main="' . get_bloginfo('template_url');
+		$str .= ' data-main="' . get_stylesheet_directory_uri();
 		$str .= '/assets/scripts/config"';
 		$str .= '></script>';
 

--- a/inc/classes/BB-Controller.class.php
+++ b/inc/classes/BB-Controller.class.php
@@ -509,6 +509,11 @@ class BackbonedController {
 			'post_count' => $this->wp_model->get('post_count')
 		);
 
+		// So theme can work with Xili and multilingual site
+		if(class_exists('xili_language')) {
+			$variables['lang'] = xili_curlang();
+		}
+
 		return $variables;
 
 	}

--- a/inc/classes/BB-Controller.class.php
+++ b/inc/classes/BB-Controller.class.php
@@ -41,7 +41,12 @@ class BackbonedController {
 			return $GLOBALS['bb_controller'];
 		}
 
-		header('X-UA-Compatible: content="IE=edge,chrome=1');
+		// Note: The X-UA-Compatible HTTP header is specific to IE.
+		//       In terms of markup recommendations, it is said better to
+		//       send an HTTP header than using a meta http-equiv tag.
+		//       http://www.validatethis.co.uk/news/fix-bad-value-x-ua-compatible-once-and-for-all/
+		header('X-UA-Compatible: IE=edge,chrome=1');
+
 		header('X-Request-type: '.$this->request_type());
 
 		// We can support child theme views folder

--- a/inc/classes/BB-Model.class.php
+++ b/inc/classes/BB-Model.class.php
@@ -190,6 +190,12 @@ class WP_Model {
 
 		$ret = array();
 
+		// Comments are closed,
+		// do not show the form
+		if ( !comments_open() ) {
+			return $ret;
+		}
+
 		if ( !$id ) {
 			return $ret;
 		}
@@ -241,7 +247,7 @@ class WP_Model {
 				'post_title' => $post->post_title,
 				'permalink' => get_permalink($post->ID),
 				'post_content' => apply_filters('the_content', wpautop($post->post_content)),
-				'nice_date' => date(get_option('date_format'), strtotime($post->post_date)),
+				'nice_date' => apply_filters('the_date', strtotime($post->post_date)),
 				'comment_count' => $post->comment_count
 			);
 
@@ -269,7 +275,7 @@ class WP_Model {
 			'ID' => $post->ID,
 			'post_title' => $post->post_title,
 			'post_content' => apply_filters('the_content', wpautop($post->post_content)),
-			'nice_date' => date(get_option('date_format'), strtotime($post->post_date)),
+			'nice_date' => apply_filters('the_date', strtotime($post->post_date)),
 			'post_author' => $post->post_author
 		);
 
@@ -295,7 +301,7 @@ class WP_Model {
 		foreach ( $comments as $comment ) {
 			$result[] = array(
 				'comment_ID' => $comment->comment_ID,
-				'nice_date' => date(get_option('date_format'), strtotime($comment->comment_date)),
+				'nice_date' => apply_filters('the_date', strtotime($comment->comment_date)),
 				'comment_author' => $comment->comment_author,
 				'comment_author_url' => $comment->comment_author_url == 'http://'
 					? ''
@@ -351,13 +357,13 @@ class WP_Model {
 		}
 
 		$post->post_content = wpautop($post->post_content);
-		$post->nice_date = date(get_option('date_format'), strtotime($post->post_date));
+		$post->nice_date = apply_filters('the_date', strtotime($post->post_date));
 
 		return array(
 			'ID' => $post->ID,
 			'post_title' => $post->post_title,
 			'post_content' => apply_filters('the_content', wpautop($post->post_content)),
-			'nice_date' => date(get_option('date_format'), strtotime($post->post_date)),
+			'nice_date' => apply_filters('the_date', strtotime($post->post_date)),
 			'post_author' => $post->post_author
 		);
 

--- a/inc/classes/BB-Model.class.php
+++ b/inc/classes/BB-Model.class.php
@@ -80,6 +80,59 @@ class WP_Model {
 	**/
 	protected function __get_main_nav() {
 
+		// See also those related functions
+		// to get menus. They had useful notes
+		// on how WP handle sorting.
+		//
+		//   - wp_nav_menu()
+		//   - wp_get_nav_menu_items()
+		//   - get_nav_menu_locations()
+		//   - wp_get_nav_menu_object()
+
+		// Assuming we have ONLY ONE menu. Otherwise it breaks.
+		$menus = wp_get_nav_menus();
+		$menu = $menus[0];
+		$menu_items = wp_get_nav_menu_items( $menu->term_id );
+
+	  // ==== /Copy-pasting code is bad, m-kay... =====
+		// This is only to sort menu like WordPress is doing it.
+		// Sorry about that.
+		// See around line 336 of wp-inclucdes/nav-menu-template.php
+		$sorted_menu_items = $menu_items_with_children = array();
+		foreach ( (array) $menu_items as $menu_item ) {
+			$sorted_menu_items[ $menu_item->menu_order ] = $menu_item;
+			if ( $menu_item->menu_item_parent )
+				$menu_items_with_children[ $menu_item->menu_item_parent ] = true;
+		}
+		if ( $menu_items_with_children ) {
+			foreach ( $sorted_menu_items as &$menu_item ) {
+				if ( isset( $menu_items_with_children[ $menu_item->ID ] ) )
+					$menu_item->classes[] = 'menu-item-has-children';
+			}
+		}
+	  // ==== /Copy-pasting code is bad, m-kay... =====
+
+		//var_dump($sorted_menu_items);
+
+		$out = array();
+
+
+		foreach($sorted_menu_items as $m) {
+			$e = array();
+			//$e['tmp'] = $m;
+			if(is_category($m->object_id)) {
+				$e['current'] = true;
+			}
+			$e['title'] = __($m->title);
+			$e['slug'] = $m->url;
+			$e['id'] = $m->ID;
+			$out[] = $e;
+		}
+		//var_dump($out);
+
+		return $out;
+
+
 		$pages = get_pages('parent=0');
 		$page_array = array();
 		$count = 0;

--- a/inc/classes/BB-Model.class.php
+++ b/inc/classes/BB-Model.class.php
@@ -115,6 +115,7 @@ class WP_Model {
 	protected function __get_categories() {
 
 		$categories = get_categories('hierarchical=0');
+
 		$category_array = array();
 
 		if ( empty($categories) ) {
@@ -264,6 +265,11 @@ class WP_Model {
 		if ( $archiveDate ) {
 			$query .= '&year=' . date('Y', $archiveDate);
 			$query .= '&monthnum=' . date('m', $archiveDate);
+		}
+
+		// So theme can work with Xili and multilingual site
+		if(class_exists('xili_language')) {
+			$query .= '&'.QUETAG.'='.xili_curlang();
 		}
 
 		$posts = query_posts($query);

--- a/inc/classes/BB-Model.class.php
+++ b/inc/classes/BB-Model.class.php
@@ -5,14 +5,43 @@
 **/
 class WP_Model {
 
+
 	protected $user;
+
+	protected $supported_errors = array();
 
 	public function __construct() {
 
 		global $current_user;
+
 		get_currentuserinfo();
+
+		$this->_init_error_messages();
+
 		$this->user = $current_user;
 
+	}
+
+	public function date_format($unixtimestamp) {
+    return strftime(get_option('date_format'), $unixtimestamp);
+	}
+
+	/**
+	 * Initialize error messages
+	 *
+	 * Maybe we would want this to be internationalized too.
+	 *
+	 * @return null
+	 */
+	protected function _init_error_messages() {
+		$errors[404]['title'] = '404 Not Found';
+		$errors[404]['message'] = 'The page you’re looking for doesn’t exist.';
+		$errors[403]['title'] = '403 Forbidden';
+		$errors[403]['message'] = 'You don’t have authorized access to view this document.';
+
+		$this->supported_errors = $errors;
+
+		return null;
 	}
 
 	/*
@@ -333,7 +362,7 @@ class WP_Model {
 		foreach ( wp_get_object_terms($id, 'category') as $category ) {
 			$categories[] = array(
 				'term_id' => $category->term_id,
-				'slug' => $category->slug,
+				'slug' => get_option( 'category_base' ) . '/category/'. $category->slug,
 				'name' => $category->name
 			);
 		}
@@ -389,18 +418,22 @@ class WP_Model {
 
 	}
 
-	/*
-	 * Content of the 404-page
+	/**
+	 * Content of the error view
 	 *
 	 * @return array
-	**/
-	protected function __get_404() {
+   **/
+	protected function __get_error($code) {
+		return $this->supported_errors[$code];
+	}
 
-		return array(
-			'title' => 'Error 404',
-			'message' => 'The page you\'re looking for doesn\'t exist.'
-		);
-
+	/**
+	 * Get list of supported errors messages
+	 *
+	 * @return array of HTTP status codes numbers
+	 */
+	public function get_supported_errors() {
+		return array_keys($this->supported_errors);
 	}
 
 }


### PR DESCRIPTION
- BackbonedController refactor, now a singleton (it feels OK in this context)
- Added condition to show comment form only when they are open
- Adjusted date format to leverage filter and user options for formatting preferences
- Better support for i18n-ed dates
- Ability to use backboned2 as a child theme
- Made error documents more generic, added 403
- Notes on how to add i18n on Mustache templates
- Refactoring BackbonedController so it is called only once
- Adding body class to use WordPress internal
